### PR TITLE
fix cross-platform desyncs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "rand",
+ "rand_xoshiro",
  "serde",
  "wasm-bindgen",
 ]
@@ -3551,6 +3552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,12 +806,13 @@ dependencies = [
 [[package]]
 name = "bevy_ggrs"
 version = "0.14.0"
-source = "git+https://github.com/aleksa2808/bevy_ggrs#d5152ea998dfdbe6602a1d97285c82fb5f4f5036"
+source = "git+https://github.com/aleksa2808/bevy_ggrs?branch=desync_fixes#5b9509291635a470cdddce0a4b90c60f4a8cd7cd"
 dependencies = [
  "bevy",
  "bytemuck",
  "ggrs",
  "log",
+ "seahash",
 ]
 
 [[package]]
@@ -3885,6 +3886,11 @@ dependencies = [
  "thiserror",
  "url",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "git+https://github.com/aleksa2808/seahash?branch=panic-on-xsize-hashing#718d67b720ac185bcadd25931a80c1da7087de17"
 
 [[package]]
 name = "sec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 rand = "0.8"
+rand_xoshiro = "0.6"
 itertools = "0.10"
 bevy_ggrs = { version = "0.14.0" }
 bytemuck = { version = "1.7", features = ["derive"] }
@@ -50,5 +51,6 @@ parking_lot = "0.12"
 wasm-bindgen = "0.2"
 
 [patch.crates-io]
+# bevy_ggrs = { path = "../bevy_ggrs" }
 bevy_ggrs = { git = "https://github.com/aleksa2808/bevy_ggrs" }
 ggrs = { git = "https://github.com/aleksa2808/ggrs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,5 @@ parking_lot = "0.12"
 wasm-bindgen = "0.2"
 
 [patch.crates-io]
-# bevy_ggrs = { path = "../bevy_ggrs" }
-bevy_ggrs = { git = "https://github.com/aleksa2808/bevy_ggrs" }
+bevy_ggrs = { git = "https://github.com/aleksa2808/bevy_ggrs", branch = "desync_fixes" }
 ggrs = { git = "https://github.com/aleksa2808/ggrs" }

--- a/src/components.rs
+++ b/src/components.rs
@@ -49,25 +49,20 @@ pub struct Dead {
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Position {
-    pub y: i8,
-    pub x: i8,
+    pub y: u8,
+    pub x: u8,
 }
 
 impl Position {
     pub fn offset(&self, direction: Direction, distance: u8) -> Self {
-        let distance = distance as i8;
-
-        let (y_offset, x_offset) = match direction {
-            Direction::Right => (0, distance),
-            Direction::Down => (distance, 0),
-            Direction::Left => (0, -distance),
-            Direction::Up => (-distance, 0),
+        let (new_y, new_x) = match direction {
+            Direction::Right => (self.y, self.x + distance),
+            Direction::Down => (self.y + distance, self.x),
+            Direction::Left => (self.y, self.x - distance),
+            Direction::Up => (self.y - distance, self.x),
         };
 
-        Position {
-            y: self.y + y_offset,
-            x: self.x + x_offset,
-        }
+        Position { y: new_y, x: new_x }
     }
 }
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -44,18 +44,18 @@ pub struct Player {
 
 #[derive(Component, Clone, Copy)]
 pub struct Dead {
-    pub cleanup_frame: usize,
+    pub cleanup_frame: u32,
 }
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Position {
-    pub y: isize,
-    pub x: isize,
+    pub y: i8,
+    pub x: i8,
 }
 
 impl Position {
-    pub fn offset(&self, direction: Direction, distance: usize) -> Self {
-        let distance = distance as isize;
+    pub fn offset(&self, direction: Direction, distance: u8) -> Self {
+        let distance = distance as i8;
 
         let (y_offset, x_offset) = match direction {
             Direction::Right => (0, distance),
@@ -73,33 +73,33 @@ impl Position {
 
 #[derive(Component, Clone, Copy, Hash)]
 pub struct BombSatchel {
-    pub bombs_available: usize,
-    pub bomb_range: usize,
+    pub bombs_available: u8,
+    pub bomb_range: u8,
 }
 
 #[derive(Component, Clone, Copy)]
 pub struct Bomb {
     pub owner: Option<PlayerID>,
-    pub range: usize,
-    pub expiration_frame: usize,
+    pub range: u8,
+    pub expiration_frame: u32,
 }
 
 #[derive(Component, Clone, Copy)]
 pub struct Moving {
     pub direction: Direction,
-    pub next_move_frame: usize,
-    pub frame_interval: usize,
+    pub next_move_frame: u32,
+    pub frame_interval: u32,
 }
 
 #[derive(Component, Clone, Copy)]
 pub struct Fuse {
     pub color: Color,
-    pub start_frame: usize,
+    pub start_frame: u32,
 }
 
 #[derive(Component, Clone, Copy)]
 pub struct Fire {
-    pub expiration_frame: usize,
+    pub expiration_frame: u32,
 }
 
 #[derive(Component, Clone, Copy)]
@@ -113,10 +113,10 @@ pub struct Destructible;
 
 #[derive(Component, Clone, Copy)]
 pub struct Crumbling {
-    pub expiration_frame: usize,
+    pub expiration_frame: u32,
 }
 
-#[derive(Component, Debug, Clone, Copy, Hash)]
+#[derive(Component, Debug, Clone, Copy)]
 pub enum Item {
     BombsUp,
     RangeUp,
@@ -125,5 +125,5 @@ pub enum Item {
 
 #[derive(Component, Clone, Copy)]
 pub struct BurningItem {
-    pub expiration_frame: usize,
+    pub expiration_frame: u32,
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -19,12 +19,12 @@ pub const COLORS: [RGBColor; 16] = [
     RGBColor(242, 242, 242),
 ];
 
-pub const PIXEL_SCALE: usize = 8;
+pub const PIXEL_SCALE: u32 = 8;
 
-pub const HUD_HEIGHT: usize = 14 * PIXEL_SCALE;
+pub const HUD_HEIGHT: u32 = 14 * PIXEL_SCALE;
 
-pub const TILE_HEIGHT: usize = 8 * PIXEL_SCALE;
-pub const TILE_WIDTH: usize = 6 * PIXEL_SCALE;
+pub const TILE_HEIGHT: u32 = 8 * PIXEL_SCALE;
+pub const TILE_WIDTH: u32 = 6 * PIXEL_SCALE;
 
 pub const WALL_Z_LAYER: f32 = 60.0;
 pub const PLAYER_Z_LAYER: f32 = 50.0;
@@ -39,21 +39,21 @@ pub const INPUT_LEFT: u8 = 1 << 2;
 pub const INPUT_RIGHT: u8 = 1 << 3;
 pub const INPUT_ACTION: u8 = 1 << 4;
 
-pub const ROUND_DURATION_SECS: usize = 60;
+pub const ROUND_DURATION_SECS: u32 = 60;
 
-pub const FPS: usize = 30;
-pub const MAX_PREDICTED_FRAMES: usize = 8;
+pub const FPS: u32 = 30;
+pub const MAX_PREDICTED_FRAMES: u32 = 8;
 
 // these must not be lower than MAX_PREDICTED_FRAMES
 // TODO can some static asserts be made?
-pub const GET_READY_DISPLAY_FRAME_COUNT: usize = 3 * FPS;
-pub const GAME_START_FREEZE_FRAME_COUNT: usize = FPS / 2;
-pub const LEADERBOARD_DISPLAY_FRAME_COUNT: usize = 2 * FPS;
-pub const TOURNAMENT_WINNER_DISPLAY_FRAME_COUNT: usize = 5 * FPS;
+pub const GET_READY_DISPLAY_FRAME_COUNT: u32 = 3 * FPS;
+pub const GAME_START_FREEZE_FRAME_COUNT: u32 = FPS / 2;
+pub const LEADERBOARD_DISPLAY_FRAME_COUNT: u32 = 2 * FPS;
+pub const TOURNAMENT_WINNER_DISPLAY_FRAME_COUNT: u32 = 5 * FPS;
 
-pub const BOMB_SHORTENED_FUSE_FRAME_COUNT: usize = 2;
+pub const BOMB_SHORTENED_FUSE_FRAME_COUNT: u32 = 2;
 
-pub const MOVING_OBJECT_FRAME_INTERVAL: usize = 1;
+pub const MOVING_OBJECT_FRAME_INTERVAL: u32 = 1;
 
 // TODO figure out if floats can be used deterministically
 pub const ITEM_SPAWN_CHANCE_PERCENTAGE: u64 = 33;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -55,5 +55,5 @@ pub const BOMB_SHORTENED_FUSE_FRAME_COUNT: usize = 2;
 
 pub const MOVING_OBJECT_FRAME_INTERVAL: usize = 1;
 
-// TODO does float precision cause desyncs?
-pub const ITEM_SPAWN_CHANCE_PERCENTAGE: usize = 33;
+// TODO figure out if floats can be used deterministically
+pub const ITEM_SPAWN_CHANCE_PERCENTAGE: u64 = 33;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub fn run() {
     let input_fn = native_input;
 
     app.add_plugins(GgrsPlugin::<GgrsConfig>::default())
-        .set_rollback_schedule_fps(FPS)
+        .set_rollback_schedule_fps(FPS as usize)
         .add_systems(ReadInputs, input_fn)
         // Bevy components
         .rollback_component_with_clone::<Sprite>()
@@ -145,8 +145,12 @@ pub fn run() {
         .checksum_component_with_hash::<Player>()
         .checksum_component_with_hash::<Position>()
         .checksum_component_with_hash::<BombSatchel>()
-        .checksum_component_with_hash::<Item>()
-        // .checksum_resource_with_hash::<SessionRng>()
+        // enums seem to hash from an isize so the derived implementation isn't portable
+        .checksum_component::<Item>(|item| match item {
+            Item::BombsUp => 0,
+            Item::RangeUp => 1,
+            Item::BombPush => 2,
+        })
         .add_systems(
             GgrsSchedule,
             // list too long for one chain

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ pub fn run() {
         .rollback_resource_with_copy::<FrameCount>()
         .rollback_resource_with_copy::<WallOfDeath>()
         .rollback_resource_with_copy::<GameFreeze>()
+        // checksums
         .checksum_component_with_hash::<Player>()
         .checksum_component_with_hash::<Position>()
         .checksum_component_with_hash::<BombSatchel>()

--- a/src/native.rs
+++ b/src/native.rs
@@ -26,7 +26,7 @@ pub struct Args {
     pub room_id: String,
 
     #[clap(long, short, default_value = "2")]
-    pub number_of_players: usize,
+    pub number_of_players: u8,
 }
 
 impl Default for Args {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -12,7 +12,7 @@ use crate::{
 #[derive(Resource)]
 pub struct NetworkStatsCooldown {
     pub cooldown: Cooldown,
-    pub print_cooldown: usize,
+    pub print_cooldown: u32,
 }
 
 #[derive(Resource)]
@@ -93,7 +93,7 @@ impl GameTextures {
         self.penguin_variants
             .iter()
             .cycle()
-            .nth(player_id.0)
+            .nth(player_id.0 as usize)
             .unwrap()
     }
 }
@@ -149,11 +149,10 @@ impl FromWorld for GameTextures {
 
 #[derive(Resource, Clone, Copy)]
 pub struct MapSize {
-    pub rows: usize,
-    pub columns: usize,
+    pub rows: u8,
+    pub columns: u8,
 }
 
-// Not to be confused with Bevy ECS `World`!
 #[derive(Resource, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(clippy::enum_variant_names)]
 pub enum WorldType {
@@ -185,7 +184,7 @@ impl WorldType {
 
 #[derive(Resource)]
 pub struct MatchboxConfig {
-    pub number_of_players: usize,
+    pub number_of_players: u8,
     pub room_id: String,
     pub matchbox_server_url: Option<String>,
     pub ice_server_config: Option<ICEServerConfig>,
@@ -213,37 +212,37 @@ impl SessionRng {
 }
 
 #[derive(Resource)]
-pub struct LocalPlayerID(pub usize);
+pub struct LocalPlayerID(pub u8);
 
 #[derive(Resource)]
 pub struct Leaderboard {
-    pub scores: HashMap<PlayerID, usize>,
-    pub winning_score: usize,
+    pub scores: HashMap<PlayerID, u8>,
+    pub winning_score: u8,
 }
 
 #[derive(Resource, Clone, Copy)]
 pub struct FrameCount {
-    pub frame: usize,
+    pub frame: u32,
 }
 
 #[derive(Resource, Clone, Copy)]
 pub enum WallOfDeath {
     Dormant {
-        activation_frame: usize,
+        activation_frame: u32,
     },
     Active {
         position: Position,
         direction: Direction,
-        next_step_frame: usize,
+        next_step_frame: u32,
     },
     Done,
 }
 
 #[derive(Resource)]
-pub struct GameEndFrame(pub usize);
+pub struct GameEndFrame(pub u32);
 
 #[derive(Resource, Clone, Copy)]
 pub struct GameFreeze {
-    pub end_frame: usize,
+    pub end_frame: u32,
     pub post_freeze_action: Option<PostFreezeAction>,
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1145,7 +1145,7 @@ pub fn wall_of_death_update(
     let get_next_position_direction =
         |mut position: Position, mut direction: Direction| -> Option<(Position, Direction)> {
             let end_position = Position {
-                y: map_size.rows as i8 - 3,
+                y: map_size.rows - 3,
                 x: 3,
             };
 
@@ -1160,23 +1160,19 @@ pub fn wall_of_death_update(
                     Position { y: 1, x: 1 } | Position { y: 2, x: 2 } => {
                         direction = Direction::Right;
                     }
-                    Position { y: 1, x } if x == map_size.columns as i8 - 2 => {
+                    Position { y: 1, x } if x == map_size.columns - 2 => {
                         direction = Direction::Down;
                     }
-                    Position { y, x }
-                        if y == map_size.rows as i8 - 2 && x == map_size.columns as i8 - 2 =>
-                    {
+                    Position { y, x } if y == map_size.rows - 2 && x == map_size.columns - 2 => {
                         direction = Direction::Left;
                     }
-                    Position { y, x: 2 } if y == map_size.rows as i8 - 2 => {
+                    Position { y, x: 2 } if y == map_size.rows - 2 => {
                         direction = Direction::Up;
                     }
-                    Position { y: 2, x } if x == map_size.columns as i8 - 3 => {
+                    Position { y: 2, x } if x == map_size.columns - 3 => {
                         direction = Direction::Down;
                     }
-                    Position { y, x }
-                        if y == map_size.rows as i8 - 3 && x == map_size.columns as i8 - 3 =>
-                    {
+                    Position { y, x } if y == map_size.rows - 3 && x == map_size.columns - 3 => {
                         direction = Direction::Left;
                     }
                     _ => (),
@@ -1249,7 +1245,7 @@ pub fn wall_of_death_update(
 
                     Some(WallOfDeath::Active {
                         position: Position {
-                            y: map_size.rows as i8 - 1,
+                            y: map_size.rows - 1,
                             x: 1,
                         },
                         direction: Direction::Up,
@@ -1324,12 +1320,7 @@ pub fn cleanup_dead(
             let invalid_item_positions: HashSet<Position> =
                 invalid_item_position_query.iter().copied().collect();
             let mut valid_positions = (1..map_size.rows - 1)
-                .flat_map(|y| {
-                    (1..map_size.columns - 1).map(move |x| Position {
-                        y: y as i8,
-                        x: x as i8,
-                    })
-                })
+                .flat_map(|y| (1..map_size.columns - 1).map(move |x| Position { y, x }))
                 .filter(|position| !invalid_item_positions.contains(position))
                 .collect_vec();
             shuffle(&mut valid_positions, &mut session_rng);

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,9 +44,9 @@ impl From<RGBColor> for BackgroundColor {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct PlayerID(pub usize);
+pub struct PlayerID(pub u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
     Left,
     Right,
@@ -58,7 +58,7 @@ impl Direction {
     pub const LIST: [Self; 4] = [Self::Right, Self::Left, Self::Up, Self::Down];
 }
 
-#[derive(Clone, Copy, Hash)]
+#[derive(Clone, Copy)]
 pub enum RoundOutcome {
     Tie,
     Winner(PlayerID),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,12 +30,12 @@ use crate::{
     types::{Direction, PlayerID, RoundOutcome},
 };
 
-pub fn get_x(x: i8) -> f32 {
-    TILE_WIDTH as f32 / 2.0 + (x as i32 * TILE_WIDTH as i32) as f32
+pub fn get_x(x: u8) -> f32 {
+    TILE_WIDTH as f32 / 2.0 + (x as u32 * TILE_WIDTH) as f32
 }
 
-pub fn get_y(y: i8) -> f32 {
-    -(TILE_HEIGHT as f32 / 2.0 + (y as i32 * TILE_HEIGHT as i32) as f32)
+pub fn get_y(y: u8) -> f32 {
+    -(TILE_HEIGHT as f32 / 2.0 + (y as u32 * TILE_HEIGHT) as f32)
 }
 
 pub fn decode(input: &str) -> String {
@@ -407,7 +407,7 @@ fn spawn_map(
         for i in 0..map_size.columns {
             commands.spawn(SpriteBundle {
                 texture: game_textures.get_map_textures(world_type).empty.clone(),
-                transform: Transform::from_xyz(get_x(i as i8), get_y(j as i8), 0.0),
+                transform: Transform::from_xyz(get_x(i), get_y(j), 0.0),
                 sprite: Sprite {
                     custom_size: Some(Vec2::new(TILE_WIDTH as f32, TILE_HEIGHT as f32)),
                     ..Default::default()
@@ -421,29 +421,26 @@ fn spawn_map(
     let mut stone_wall_positions = HashSet::new();
     for i in 0..map_size.rows {
         // left
-        stone_wall_positions.insert(Position { y: i as i8, x: 0 });
+        stone_wall_positions.insert(Position { y: i, x: 0 });
         // right
         stone_wall_positions.insert(Position {
-            y: i as i8,
-            x: (map_size.columns - 1) as i8,
+            y: i,
+            x: (map_size.columns - 1),
         });
     }
     for i in 1..map_size.columns - 1 {
         // top
-        stone_wall_positions.insert(Position { y: 0, x: i as i8 });
+        stone_wall_positions.insert(Position { y: 0, x: i });
         // bottom
         stone_wall_positions.insert(Position {
-            y: (map_size.rows - 1) as i8,
-            x: i as i8,
+            y: (map_size.rows - 1),
+            x: i,
         });
     }
     // checkered middle
     for i in (2..map_size.rows).step_by(2) {
         for j in (2..map_size.columns).step_by(2) {
-            stone_wall_positions.insert(Position {
-                y: i as i8,
-                x: j as i8,
-            });
+            stone_wall_positions.insert(Position { y: i, x: j });
         }
     }
 
@@ -465,12 +462,7 @@ fn spawn_map(
     }
 
     let mut destructible_wall_potential_positions: HashSet<Position> = (0..map_size.rows)
-        .flat_map(|y| {
-            (0..map_size.columns).map(move |x| Position {
-                y: y as i8,
-                x: x as i8,
-            })
-        })
+        .flat_map(|y| (0..map_size.columns).map(move |x| Position { y, x }))
         .filter(|p| !stone_wall_positions.contains(p))
         .collect();
 
@@ -591,13 +583,9 @@ pub fn setup_round(
         (3, map_size.columns - 6),
         (map_size.rows - 4, 5),
     ];
-    let mut possible_player_spawn_positions =
-        possible_player_spawn_positions
-            .iter()
-            .map(|(y, x)| Position {
-                y: *y as i8,
-                x: *x as i8,
-            });
+    let mut possible_player_spawn_positions = possible_player_spawn_positions
+        .iter()
+        .map(|(y, x)| Position { y: *y, x: *x });
 
     let mut player_spawn_positions = vec![];
     for player_id in player_ids {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,11 +31,11 @@ use crate::{
 };
 
 pub fn get_x(x: i8) -> f32 {
-    TILE_WIDTH as f32 / 2.0 + (x * TILE_WIDTH as i8) as f32
+    TILE_WIDTH as f32 / 2.0 + (x as i32 * TILE_WIDTH as i32) as f32
 }
 
 pub fn get_y(y: i8) -> f32 {
-    -(TILE_HEIGHT as f32 / 2.0 + (y * TILE_HEIGHT as i8) as f32)
+    -(TILE_HEIGHT as f32 / 2.0 + (y as i32 * TILE_HEIGHT as i32) as f32)
 }
 
 pub fn decode(input: &str) -> String {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,7 +44,7 @@ pub fn decode(input: &str) -> String {
 
 pub fn shuffle<T>(elements: &mut [T], rng: &mut SessionRng) {
     for i in (1..elements.len()).rev() {
-        elements.swap(i, rng.gen_u64() as usize % (i + 1));
+        elements.swap(i, (rng.gen_u64() % (i as u64 + 1)) as usize);
     }
 }
 
@@ -492,15 +492,11 @@ fn spawn_map(
     }
 
     let number_of_players = player_spawn_positions.len();
-    // TODO remove f32 and this panic
-    let percent_of_passable_positions_to_fill = match number_of_players {
-        2..=3 => 40.0,
-        4..=8 => 50.0,
+    let num_of_destructible_walls_to_place = match number_of_players {
+        2..=3 => number_of_passable_positions / 5 * 2,
+        4..=8 => number_of_passable_positions / 2,
         _ => unreachable!(),
     };
-    let num_of_destructible_walls_to_place = (number_of_passable_positions as f32
-        * percent_of_passable_positions_to_fill
-        / 100.0) as usize;
     if destructible_wall_potential_positions.len() < num_of_destructible_walls_to_place {
         panic!(
             "Not enough passable positions available for placing destructible walls. Have {}, but need at least {}",
@@ -511,7 +507,7 @@ fn spawn_map(
 
     let mut destructible_wall_positions = destructible_wall_potential_positions
         .into_iter()
-        .sorted_by_key(|p| (p.x, p.y))
+        .sorted()
         .collect_vec();
     shuffle(&mut destructible_wall_positions, rng);
     for position in destructible_wall_positions

--- a/src/web.rs
+++ b/src/web.rs
@@ -13,7 +13,7 @@ use crate::{
     AppState,
 };
 
-static START: Lazy<RwLock<Option<(usize, String, String, String, String, String)>>> =
+static START: Lazy<RwLock<Option<(u8, String, String, String, String, String)>>> =
     Lazy::new(|| RwLock::new(None));
 static INPUTS: Lazy<RwLock<VecDeque<u8>>> = Lazy::new(|| RwLock::new(VecDeque::new()));
 
@@ -21,7 +21,7 @@ static INPUTS: Lazy<RwLock<VecDeque<u8>>> = Lazy::new(|| RwLock::new(VecDeque::n
 #[wasm_bindgen]
 #[allow(dead_code)]
 pub fn start_game(
-    number_of_players: usize,
+    number_of_players: u8,
     room_id: &str,
     matchbox_server_url: &str,
     ice_server_url: &str,
@@ -115,7 +115,7 @@ pub fn web_ready_to_start_update(
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum InputAction {
     Up,
     Down,


### PR DESCRIPTION
Native and WASM builds could not play together without immediately running into desyncs. This PR fixes several sources of desyncs to enable cross platform play, including:
* switching the checksum hashing to a portable implementation
* switching the random number generator to a portable implementation
* replacing many instances of `usize` and `isize` with explicitly sized types